### PR TITLE
Minor adjustements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules
 *.log
 .DS_Store
-dist

--- a/OTKit/otkit-colors/package.json
+++ b/OTKit/otkit-colors/package.json
@@ -6,8 +6,13 @@
     "name": "Nick Balestra",
     "email": "nick@balestra.ch"
   },
-  "files": [
-    "dist"
-  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/opentable/design-tokens.git"
+  },
+  "bugs": {
+    "url": "https://github.com/opentable/design-tokens/issues"
+  },
+  "homepage": "https://github.com/opentable/design-tokens/tree/master/OTKit/otkit-colors#readme",
   "license": "MIT"
 }

--- a/OTKit/otkit-spacing/package.json
+++ b/OTKit/otkit-spacing/package.json
@@ -6,8 +6,13 @@
     "name": "Nick Balestra",
     "email": "nick@balestra.ch"
   },
-  "files": [
-    "dist"
-  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/opentable/design-tokens.git"
+  },
+  "bugs": {
+    "url": "https://github.com/opentable/design-tokens/issues"
+  },
+  "homepage": "https://github.com/opentable/design-tokens/tree/master/OTKit/otkit-spacing#readme",
   "license": "MIT"
 }

--- a/OTTheme/ottheme-colors/package.json
+++ b/OTTheme/ottheme-colors/package.json
@@ -6,8 +6,13 @@
     "name": "Nick Balestra",
     "email": "nick@balestra.ch"
   },
-  "files": [
-    "dist"
-  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/opentable/design-tokens.git"
+  },
+  "bugs": {
+    "url": "https://github.com/opentable/design-tokens/issues"
+  },
+  "homepage": "https://github.com/opentable/design-tokens/tree/master/OTTheme/ottheme-colors#readme",
   "license": "MIT"
 }

--- a/OTTheme/ottheme-spacing/package.json
+++ b/OTTheme/ottheme-spacing/package.json
@@ -6,8 +6,13 @@
     "name": "Nick Balestra",
     "email": "nick@balestra.ch"
   },
-  "files": [
-    "dist"
-  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/opentable/design-tokens.git"
+  },
+  "bugs": {
+    "url": "https://github.com/opentable/design-tokens/issues"
+  },
+  "homepage": "https://github.com/opentable/design-tokens/tree/master/OTTheme/ottheme-spacing#readme",
   "license": "MIT"
 }

--- a/README.md
+++ b/README.md
@@ -16,3 +16,11 @@ Design-tokens used by OpenTable systems:
 |--------|-------|-------|
 | [`ottheme-colors`](/OTTheme/ottheme-colors) | `scss` | [![npm version](https://badge.fury.io/js/ottheme-colors.svg)](http://badge.fury.io/js/ottheme-colors) |
 | [`ottheme-spacing`](/OTTheme/ottheme-spacing) | `scss` | [![npm version](https://badge.fury.io/js/ottheme-spacing.svg)](http://badge.fury.io/js/ottheme-spacing) |
+
+***
+
+## Tools:
+
+| Package | Description | Version |
+|--------|-------|-------|
+| [`theo-cli`](/tools/theo-cli) | CLI for [Theo](https://github.com/salesforce-ux/theo) | [![npm version](https://badge.fury.io/js/theo-cli.svg)](http://badge.fury.io/js/theo-cli) |

--- a/tools/theo-cli/README.md
+++ b/tools/theo-cli/README.md
@@ -34,8 +34,7 @@ and it will generate the following build structure:
 yourToken/
 ├── node_modules/
 ├── token.yml
-├── dist/
-│   └── index.<theo-format>
+├── token.<format>
 └── package.json
 ```
 
@@ -74,8 +73,8 @@ $ theo scss cssmodules.css
 |Name|Description|Default|
 |----|-----------|-------|
 |`--path` \| `-p` |The absolute path where source token is located|`process.cwd`|
-|`--dist` \| `-d` |The relative path where to generate the build|`dist/`|
-|`--output` \| `-o` |The output filename|`index.<format>` |
+|`--dist` \| `-d` |The relative path where to generate the build|`.`|
+|`--output` \| `-o` |The output filename|`token.<format>` |
 |`--src` \| `-s` |The src file|`token.yml` |
 
 

--- a/tools/theo-cli/README.md
+++ b/tools/theo-cli/README.md
@@ -93,10 +93,8 @@ Typically you'll use this in your [npm scripts](https://docs.npmjs.com/misc/scri
 the following result will be printed on your terminal:
 
 ```
-✏️  scss tokens created at "yourToken/dist/index.scss"
-✏️  cssmodules.css tokens created at "yourToken/dist/index.cssmodules.css"
-✏️  cssmodules.css tokens created at "yourToken/dist/index.cssmodules.css"
-✏️  scss tokens created at "yourToken/dist/index.scss"
+✏️  scss tokens created at "yourToken/token.scss"
+✏️  cssmodules.css tokens created at "yourToken/token.cssmodules.css"
 ```
 
 ## MonoRepo with Lerna

--- a/tools/theo-cli/scripts/build.js
+++ b/tools/theo-cli/scripts/build.js
@@ -7,8 +7,8 @@ const argv = require('optimist').argv;
 
 const formats = argv._;
 const packagePath = argv.path || argv.p || process.cwd();
-const distPath = argv.dist || argv.d || 'dist';
-const fileName = argv.output || argv.o || 'index';
+const distPath = argv.dist || argv.d || '.';
+const fileName = argv.output || argv.o || 'token';
 const source = argv.src || argv.s || 'token.yml';
 
 fs.emptyDir(path.join(packagePath, 'dist'))


### PR DESCRIPTION
- added minor left out on the various packages in preparation for publishing
- bette defaults for the build so consuming will look like `require('otkit-spacing/token.cssmodules.css')` (no need for a `dist/`)