### PR TITLE
[RUSH-792] Improve documentation of OTKit around save-dev, minor fixes

### DIFF
--- a/OTKit/README.md
+++ b/OTKit/README.md
@@ -11,15 +11,21 @@
 
 ## Usage
 
-Add the needed tokens to your devDependnecies:
+Run the command below will add the needed tokens to your project:
 
+```bash
+$ npm install --save-dev <token-name>
 ```
-$ npm install save-dev <token-name>
+
+Or you can manually add the `<token-name>` package line to your project's `devDependnecies` inside `package.json`, then run:
+
+```bash
+$ npm install
 ```
 
-Note: Dependending on the format that you wish to consume requiring could work differently.
+A Token can be consumed multiple available formats (listed above); requiring the token could work differently based on the format you wish to consume.
 
-Example to consume cssmodules.css format of the colors token, inside your css file: 
+For example, to consume `cssmodules.css` format of the `otkit-colors` token, you will need to add this inside your css file:
 
 ```css
 @value color-primary from 'otkit-colors/token.cssmodules.css';
@@ -29,9 +35,9 @@ Example to consume cssmodules.css format of the colors token, inside your css fi
 
 ## Contributing
 
-All the design related information are aliased and contained within the [aliases.yml](/aliases/yml) file. This is represent the single source of truth for a specific system and those aliases are then reused within each tokens for build purpose. 
+All the design related information are aliased and contained within the [aliases.yml](/aliases/yml) file. This is represent the single source of truth for a specific system and those aliases are then reused within each token for build purpose.
 
-### I need to ad a new color, where do we add it?
+### I need to add a new color, where do I add it?
 
 1. Add the unique name and value for which we intend to represent this color within the company in the [aliases.yml](/aliases/yml) file, for example:
 
@@ -54,7 +60,7 @@ props:
   ...  
 ```
 
-### I need to ad a new format, how do we add it?
+### I need to add a new format, how do I add it?
 
 1. Edit the related build system in the project root scripts (within the `package.json` file). Check the [theo](https://github.com/salesforce-ux/theo#available-formats) and [theo-cli](https://github.com/opentable/design-tokens/tree/master/tools/theo-cli#theo-cli) documentation for more information.
 


### PR DESCRIPTION
# Description
This PR primarily aims to resolve some confusion around `save-dev` in the current OTKit documentation. It also includes some very minor typo and formatting fixes.

Going forward I plan to continue polishing and adding to the documentations as we develop more with design tokens.

# Ticket
https://opentable.atlassian.net/browse/RUSH-792