### PR TITLE
[OC-92] Typography token

### DIFF
--- a/OTKit/otkit-typography/LICENSE
+++ b/OTKit/otkit-typography/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2017 OpenTable, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/OTKit/otkit-typography/package.json
+++ b/OTKit/otkit-typography/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "otkit-typography",
+  "version": "1.0.0",
+  "description": "OpenTable typography design token",
+  "author": {
+    "name": "Nick Balestra",
+    "email": "nick@balestra.ch"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/opentable/design-tokens.git"
+  },
+  "bugs": {
+    "url": "https://github.com/opentable/design-tokens/issues"
+  },
+  "homepage": "https://github.com/opentable/design-tokens/tree/master/OTKit/#readme",
+  "license": "MIT"
+}

--- a/OTKit/otkit-typography/token.yml
+++ b/OTKit/otkit-typography/token.yml
@@ -1,0 +1,11 @@
+props:
+# TODO
+  something:
+    type: "size"
+    value: "{!spacing-xsmall}"
+
+imports:
+  - ../aliases.yml
+
+global:
+  category: "typography"


### PR DESCRIPTION
@lastquestion I've created a scaffholding for the typography token.

When working on it, please rely on the [aliases](https://github.com/opentable/design-tokens/blob/master/OTKit/aliases.yml) file for storing all alias/value and then use those within the token itself. 

This allows for non duplicating and reuse of values among tokens if/when needed. (spacing and colors already rely on it). It also make for designer even easier as they most probably want to focus their work on that file first. If you need anything, please do let me know.