### PR TITLE
RUSH-1085 Fix types of font weights, add docs about preview & debug

### DIFF
--- a/OTKit/README.md
+++ b/OTKit/README.md
@@ -39,6 +39,14 @@ import color from 'otkit-colors/token.common.js';
 @import '../node_modules/ottheme-colors/token.scss';
 ```
 
+Preview & debug the token:
+
+Executing `npm run build` will generate the token values in each token's folder, such as `token.scss` or other available formats you specified.
+
+When you publish a token, this step is executed as part of the publishing.
+
+If you are using a token in your project, you can execute `npm link '<token-name>'` in `node_modules` folder to test the token values before publishing.
+
 ***
 
 ## Contributing

--- a/OTKit/otkit-typography/token.yml
+++ b/OTKit/otkit-typography/token.yml
@@ -30,13 +30,13 @@ props:
     type: "size"
     value: "{!line-height-xlarge}"
   font-weight-normal:
-    type: "string"
+    type: "raw"
     value: "{!font-weight-normal}"
   font-weight-medium:
     type: "number"
     value: "{!font-weight-medium}"
   font-weight-bold:
-    type: "string"
+    type: "raw"
     value: "{!font-weight-bold}"
   font-name:
     type: "string"


### PR DESCRIPTION
### Overview
This PR changes the type of `font-weight-normal` and `font-weight-bold` to a special "raw" type instead of string, so that values can be parsed by Theo correctly without quotation marks around. This will ensure font weight is properly calculated in start page.

Browser won't be able to parse it if type is "string":
![image](https://user-images.githubusercontent.com/1095291/30654571-2ee9dc3a-9e26-11e7-87bd-3af9da769853.png)

This PR also adds some documentation on how to preview and debug a token's generated values.

### Special note on the type `raw`

Theo, the design token parser we use, has a preset of types that each maps to a special transformer to do processing. For example, type `string` adds quotation marks around, type `color` does RGBA format conversion, etc. The new type I defined here, `raw` is actually NOT in the supported Theo transformer list, which means it will preserve the value as is, achieving what we wanted.

### Ticket
https://opentable.atlassian.net/browse/RUSH-1085