### PR TITLE
[DO NOT MERGE][MINOR] Modified color-primary-disabled. Updated color-primary-active

### DIFF
--- a/OTKit/aliases.yml
+++ b/OTKit/aliases.yml
@@ -9,16 +9,14 @@ aliases:
   color-primary:
     value: "#DA3743"
   color-primary-active:
-    value: "#FB665F"
-  color-primary-disabled:
-    value: "rgba(218, 55, 67, 0.40)"
+    value: "#AE2C35"
 
   # Primary Gray, used on all text sizes
   # =============================================
   color-gray-primary:
     value: "#333333"
 
-  # Secondary Gray, used on smaller font sizes
+  # Secondary Gray, used on smaller font sizes and for disabled primary buttons
   # =============================================
   color-gray-secondary:
     value: "#717171"

--- a/OTKit/otkit-colors/token.yml
+++ b/OTKit/otkit-colors/token.yml
@@ -4,7 +4,7 @@ props:
   color-primary-active:
     value: "{!color-primary-active}"
   color-primary-disabled:
-    value: "{!color-primary-disabled}"
+    value: "{!color-gray-secondary}"
   color-gray-primary:
     value: "{!color-gray-primary}"
   color-gray-secondary:


### PR DESCRIPTION
- Deleted color-primary-disabled in aliases.yml, as it doesn't have it's own independent value (it is equivalent to color-gray-secondary). Developers can still use the variable under its new definition, as defined in token.yml in otkit-colors.

- Updated color-primary-active. The hex value was out of date.