### PR TITLE
[RUSH-886] Added OTKit desktop web typography token, added platform metadata

### DIFF
--- a/OTKit/otkit-breakpoints/token.yml
+++ b/OTKit/otkit-breakpoints/token.yml
@@ -6,5 +6,6 @@ imports:
   - ../aliases.yml
 
 global:
+  platform: "core"
   type: "breakpoints"
   category: "breakpoints"

--- a/OTKit/otkit-colors/token.yml
+++ b/OTKit/otkit-colors/token.yml
@@ -16,5 +16,6 @@ imports:
   - ../aliases.yml
 
 global:
+  platform: "core"
   type: "color"
-  category: "colors"
+  category: "color"

--- a/OTKit/otkit-desktop-typography/package.json
+++ b/OTKit/otkit-desktop-typography/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "otkit-desktop-typography",
+  "version": "1.0.0",
+  "description": "OpenTable desktop web typography design token",
+  "author": {
+    "name": "Vincent Zhang",
+    "email": "v@vincentzh.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/opentable/design-tokens.git"
+  },
+  "bugs": {
+    "url": "https://github.com/opentable/design-tokens/issues"
+  },
+  "homepage": "https://github.com/opentable/design-tokens/tree/master/OTKit/#readme",
+  "license": "MIT"
+}

--- a/OTKit/otkit-desktop-typography/token.yml
+++ b/OTKit/otkit-desktop-typography/token.yml
@@ -1,0 +1,74 @@
+props:
+  heading-xlarge-font-size:
+    type: "size"
+    value: "{!font-size-xlarge}"
+  heading-xlarge-font-weight:
+    type: "raw"
+    value: "{!font-weight-bold}"
+  heading-xlarge-line-height:
+    type: "size"
+    value: "{!line-height-xlarge}"
+
+  heading-large-font-size:
+    type: "size"
+    value: "{!font-size-large}"
+  heading-large-font-weight:
+    type: "raw"
+    value: "{!font-weight-bold}"
+  heading-large-font-weight-alternate:
+    type: "raw"
+    value: "{!font-weight-normal}"
+  heading-large-line-height:
+    type: "size"
+    value: "{!line-height-large}"
+
+  heading-medium-font-size:
+    type: "size"
+    value: "{!font-size-medium}"
+  heading-medium-font-weight:
+    type: "raw"
+    value: "{!font-weight-medium}"
+  heading-medium-line-height:
+    type: "size"
+    value: "{!line-height-medium}"
+
+  subheading-small-font-size:
+    type: "size"
+    value: "{!font-size-small}"
+  subheading-small-font-weight:
+    type: "raw"
+    value: "{!font-weight-medium}"
+  subheading-small-line-height:
+    type: "size"
+    value: "{!line-height-small}"
+
+  bodytext-small-font-size:
+    type: "size"
+    value: "{!font-size-small}"
+  bodytext-small-font-weight:
+    type: "raw"
+    value: "{!font-weight-normal}"
+  bodytext-small-line-height:
+    type: "size"
+    value: "{!line-height-small}"
+
+  subtext-xsmall-font-size:
+    type: "size"
+    value: "{!font-size-xsmall}"
+  subtext-xsmall-font-weight:
+    type: "raw"
+    value: "{!font-weight-medium}"
+  subtext-xsmall-font-weight-alternate:
+    type: "raw"
+    value: "{!font-weight-normal}"
+  subtext-xsmall-line-height:
+    type: "size"
+    value: "{!line-height-xsmall}"
+
+imports:
+  - ../aliases.yml
+
+global:
+  platform: "desktop"
+  type: "typography"
+  category: "typography"

--- a/OTKit/otkit-spacing/token.yml
+++ b/OTKit/otkit-spacing/token.yml
@@ -14,5 +14,6 @@ imports:
   - ../aliases.yml
 
 global:
+  platform: "core"
   type: "spacing"
   category: "spacing"

--- a/OTKit/otkit-typography/token.yml
+++ b/OTKit/otkit-typography/token.yml
@@ -46,4 +46,5 @@ imports:
   - ../aliases.yml
 
 global:
+  platform: "core"
   category: "typography"


### PR DESCRIPTION
This PR is taking over https://github.com/opentable/design-tokens/pull/48 so I will paste the original description below.

These typography style groupings are based on Kellen's design spec: https://opentable.invisionapp.com/boards/SP3ARCZNYQXEK/ 

### Overview
This PR is based on @lastquestion's PR https://github.com/opentable/design-tokens/pull/32. The discussion related to this ticket can be found [here](https://github.com/opentable/design-tokens/issues/26).

The purpose of this PR is to introduce a batch of platform specific values that are composed of the "original", platform agnostic values.

The start page implementation can be found here: https://github.com/opentable/start-page-nodejs/pull/3056, check out its description and comments for more context.

### Ticket
https://opentable.atlassian.net/browse/RUSH-886