### PR TITLE
Added otkit-desktop-typography readme & license

### DIFF
--- a/OTKit/otkit-desktop-typography/LICENSE
+++ b/OTKit/otkit-desktop-typography/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2017 OpenTable, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/OTKit/otkit-desktop-typography/token.yml
+++ b/OTKit/otkit-desktop-typography/token.yml
@@ -38,9 +38,6 @@ props:
   subheading-small-font-weight:
     type: "raw"
     value: "{!font-weight-medium}"
-  subheading-small-font-weight-alternate:
-    type: "raw"
-    value: "{!font-weight-normal}"
   subheading-small-line-height:
     type: "size"
     value: "{!line-height-small}"

--- a/OTKit/otkit-desktop-typography/token.yml
+++ b/OTKit/otkit-desktop-typography/token.yml
@@ -38,6 +38,9 @@ props:
   subheading-small-font-weight:
     type: "raw"
     value: "{!font-weight-medium}"
+  subheading-small-font-weight-alternate:
+    type: "raw"
+    value: "{!font-weight-normal}"
   subheading-small-line-height:
     type: "size"
     value: "{!line-height-small}"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This project is structured to host design-tokens used by the following OpenTable
 | [`otkit-colors`](/OTKit/otkit-colors) | `scss, cssmodules.css, common.js` | [![npm version](https://badge.fury.io/js/otkit-colors.svg)](http://badge.fury.io/js/otkit-colors) |
 | [`otkit-spacing`](/OTKit/otkit-spacing) | `scss, cssmodules.css, common.js` | [![npm version](https://badge.fury.io/js/otkit-spacing.svg)](http://badge.fury.io/js/otkit-spacing) |
 | [`otkit-typography`](/OTKit/otkit-typography) | `scss, cssmodules.css, common.js` | [![npm version](https://badge.fury.io/js/otkit-typography.svg)](http://badge.fury.io/js/otkit-typography) |
+| [`otkit-desktop-typography`](/OTKit/otkit-desktop-typography) | `scss, cssmodules.css, common.js` | [![npm version](https://badge.fury.io/js/otkit-desktop-typography.svg)](http://badge.fury.io/js/otkit-desktop-typography) |
 
 
 ### OTTheme - [Documentation](https://github.com/opentable/design-tokens/blob/master/OTTheme/README.md)


### PR DESCRIPTION
## Overview

This PR adds the new token to README (it existed since #64).

This PR also adds the missing license file.