### PR TITLE
[HOUSEKEEPING] Replace personal details with official communal group account

### DIFF
--- a/OTKit/otkit-colors/package.json
+++ b/OTKit/otkit-colors/package.json
@@ -3,8 +3,7 @@
   "version": "2.2.1",
   "description": "OpenTable colors design token",
   "author": {
-    "name": "Nick Balestra",
-    "email": "nick@balestra.ch"
+    "email": "design-tokens@opentable.com"
   },
   "repository": {
     "type": "git",

--- a/OTKit/otkit-desktop-typography/package.json
+++ b/OTKit/otkit-desktop-typography/package.json
@@ -3,8 +3,7 @@
   "version": "2.0.0",
   "description": "OpenTable desktop web typography design token",
   "author": {
-    "name": "Vincent Zhang",
-    "email": "v@vincentzh.com"
+    "email": "design-tokens@opentable.com"
   },
   "repository": {
     "type": "git",

--- a/OTKit/otkit-spacing/package.json
+++ b/OTKit/otkit-spacing/package.json
@@ -3,8 +3,7 @@
   "version": "2.0.1",
   "description": "OpenTable spacing design token",
   "author": {
-    "name": "Nick Balestra",
-    "email": "nick@balestra.ch"
+    "email": "design-tokens@opentable.com"
   },
   "repository": {
     "type": "git",

--- a/OTKit/otkit-typography/package.json
+++ b/OTKit/otkit-typography/package.json
@@ -3,8 +3,7 @@
   "version": "2.0.0",
   "description": "OpenTable typography design token",
   "author": {
-    "name": "Nick Balestra",
-    "email": "nick@balestra.ch"
+    "email": "design-tokens@opentable.com"
   },
   "repository": {
     "type": "git",

--- a/OTTheme/ottheme-colors/package.json
+++ b/OTTheme/ottheme-colors/package.json
@@ -3,8 +3,7 @@
   "version": "1.2.0",
   "description": "OpenTable colors design token",
   "author": {
-    "name": "Nick Balestra",
-    "email": "nick@balestra.ch"
+    "email": "design-tokens@opentable.com"
   },
   "repository": {
     "type": "git",

--- a/OTTheme/ottheme-spacing/package.json
+++ b/OTTheme/ottheme-spacing/package.json
@@ -3,8 +3,7 @@
   "version": "1.0.3",
   "description": "OpenTable spacing design token",
   "author": {
-    "name": "Nick Balestra",
-    "email": "nick@balestra.ch"
+    "email": "design-tokens@opentable.com"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Overview
This PR replaces developers' personal details with the official communal group account for design tokens.

Motivation: some of our contributors feels uncomfortable putting personal information in the author field of a company-owned open sourced project.

Analysis: we overall support the decision to remove personal details from these tokens, because:
 - Design tokens encourage collaboration and shared ownership; a pool of community contributors help to make each token better, having a singular author doesn't represent (and discourages) this reality;
 - This author info gets outdated once that person decided to not get involved with this project anymore, or even worse, leave the company; this could be a liability concern down the road;
 - None of the other prominent design token systems (Skyscanner, Salesforce, etc) put developer's personal detail in author field. They all have a communal group account as the author for easier contact; this is industry standard for providing better support.