### PR TITLE
[DX-397] Style guide alt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ node_modules
 *.scss
 *.cssmodules.css
 *.common.js
+.cache
+public

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-minimal

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,0 @@
-# OTKit Style Guide
-
-This is where our visual style guide will live.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-minimal

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,8 @@
   "lerna": "2.0.0",
   "packages": [
     "OTTheme/*",
-    "OTKit/*"
+    "OTKit/*",
+    "style-guide"
   ],
   "version": "independent"
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,20 @@
 {
   "devDependencies": {
     "doctoc": "^1.3.0",
-    "lerna": "^2.0.0",
-    "theo": "^6.0.0-beta.4"
+    "lerna": "^2.8.0",
+    "theo": "^6.0.0",
+    "npm-watch": "^0.3.0",
+    "concurrently": "^3.5.1"
+  },
+  "watch": {
+    "build": {
+      "patterns": [
+        "OTKit",
+        "OTTheme"
+      ],
+      "extensions": "yml",
+      "delay": 0
+    }
   },
   "scripts": {
     "build": "npm run build-ottheme && npm run build-otkit",
@@ -14,6 +26,6 @@
     "updatetoc": "doctoc README.md --github",
     "publish": "npm run build && lerna publish",
     "updated": "lerna updated",
-    "develop": "lerna exec --scope style-guide npm run develop"
+    "develop": "concurrently 'lerna exec --scope style-guide npm run develop' 'npm-watch'"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "postinstall": "lerna bootstrap",
     "updatetoc": "doctoc README.md --github",
     "publish": "npm run build && lerna publish",
-    "updated": "lerna updated"
+    "updated": "lerna updated",
+    "develop": "lerna exec --scope style-guide npm run develop"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "postinstall": "lerna bootstrap",
     "updatetoc": "doctoc README.md --github",
     "publish": "npm run build && lerna publish --exact",
+    "postpublish": "npm run deploy-styleguide",
     "updated": "lerna updated",
-    "develop": "concurrently 'lerna exec --scope style-guide npm run develop' 'npm-watch'"
+    "develop": "concurrently 'lerna exec --scope style-guide npm run develop' 'npm-watch'",
+    "deploy-styleguide": "lerna exec --scope style-guide npm run deploy"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,18 +6,8 @@
     "npm-watch": "^0.3.0",
     "concurrently": "^3.5.1"
   },
-  "watch": {
-    "build": {
-      "patterns": [
-        "OTKit",
-        "OTTheme"
-      ],
-      "extensions": "yml",
-      "delay": 0
-    }
-  },
   "scripts": {
-    "build": "npm run build-ottheme && npm run build-otkit",
+    "build": "npm run build-otkit && npm run build-ottheme",
     "build-ottheme": "lerna exec --scope ottheme-* theo token.yml -- --transform web --format scss,cssmodules.css,common.js --dest .",
     "build-otkit": "lerna exec --scope otkit-* theo token.yml -- --transform web --format scss,cssmodules.css,common.js --dest .",
     "clean": "lerna clean",
@@ -27,5 +17,15 @@
     "publish": "npm run build && lerna publish",
     "updated": "lerna updated",
     "develop": "concurrently 'lerna exec --scope style-guide npm run develop' 'npm-watch'"
+  },
+  "watch": {
+    "build": {
+      "patterns": [
+        "OTKit",
+        "OTTheme"
+      ],
+      "extensions": "yml",
+      "delay": 0
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,18 +6,6 @@
     "npm-watch": "^0.3.0",
     "concurrently": "^3.5.1"
   },
-  "scripts": {
-    "build": "npm run build-otkit && npm run build-ottheme",
-    "build-ottheme": "lerna exec --scope ottheme-* theo token.yml -- --transform web --format scss,cssmodules.css,common.js --dest .",
-    "build-otkit": "lerna exec --scope otkit-* theo token.yml -- --transform web --format scss,cssmodules.css,common.js --dest .",
-    "clean": "lerna clean",
-    "test": "lerna exec --scope ot* theo token.yml -- --transform web --format scss,cssmodules.css,common.js",
-    "postinstall": "lerna bootstrap",
-    "updatetoc": "doctoc README.md --github",
-    "publish": "npm run build && lerna publish",
-    "updated": "lerna updated",
-    "develop": "concurrently 'lerna exec --scope style-guide npm run develop' 'npm-watch'"
-  },
   "watch": {
     "build": {
       "patterns": [
@@ -27,5 +15,17 @@
       "extensions": "yml",
       "delay": 0
     }
+  },
+  "scripts": {
+    "build": "npm run build-ottheme && npm run build-otkit",
+    "build-ottheme": "lerna exec --scope ottheme-* theo token.yml -- --transform web --format scss,cssmodules.css,common.js --dest .",
+    "build-otkit": "lerna exec --scope otkit-* theo token.yml -- --transform web --format scss,cssmodules.css,common.js --dest .",
+    "clean": "lerna clean",
+    "test": "lerna exec --scope ot* theo token.yml -- --transform web --format scss,cssmodules.css,common.js",
+    "postinstall": "lerna bootstrap",
+    "updatetoc": "doctoc README.md --github",
+    "publish": "npm run build && lerna publish --exact",
+    "updated": "lerna updated",
+    "develop": "concurrently 'lerna exec --scope style-guide npm run develop' 'npm-watch'"
   }
 }

--- a/style-guide/README.md
+++ b/style-guide/README.md
@@ -1,0 +1,3 @@
+# OTKit Style Guide
+
+This is where our visual style guide will live.

--- a/style-guide/gatsby-config.js
+++ b/style-guide/gatsby-config.js
@@ -1,3 +1,4 @@
-{
-  pathPrefix: "/design-tokens"; // as in https://opentable.github.io/design-tokens
-}
+module.exports = {
+  pathPrefix: '/design-tokens', // as in https://opentable.github.io/design-tokens
+  plugins: []
+};

--- a/style-guide/gatsby-config.js
+++ b/style-guide/gatsby-config.js
@@ -1,0 +1,3 @@
+{
+  pathPrefix: "/design-tokens"; // as in https://opentable.github.io/design-tokens
+}

--- a/style-guide/package.json
+++ b/style-guide/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "gatsby": "^1.9.181",
-    "otkit-desktop-typography": "2.0.0"
+    "otkit-desktop-typography": "2.0.1"
   },
   "devDependencies": {
     "gh-pages": "^1.1.0"

--- a/style-guide/package.json
+++ b/style-guide/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "style-guide",
+  "private": true,
+  "version": "0.0.1",
+  "description": "Static Style Guide for OpenTable's Design-Tokens",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/opentable/design-tokens"
+  },
+  "homepage": "https://opentable.github.io/design-tokens/",
+  "scripts": {
+    "develop": "gatsby develop",
+    "build": "gatsby build",
+    "serve": "gatsby serve",
+    "deploy": "gatsby build --prefix-paths && gh-pages -d public"
+  },
+  "dependencies": {
+    "gatsby": "^1.9.181",
+    "otkit-desktop-typography": "2.0.1"
+  },
+  "devDependencies": {
+    "gh-pages": "^1.1.0"
+  }
+}

--- a/style-guide/package.json
+++ b/style-guide/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "gatsby": "^1.9.181",
+    "gatsby-link":"^1.6.36",
     "otkit-desktop-typography": "2.0.1"
   },
   "devDependencies": {

--- a/style-guide/package.json
+++ b/style-guide/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "gatsby": "^1.9.181",
-    "otkit-desktop-typography": "2.0.1"
+    "otkit-desktop-typography": "2.0.0"
   },
   "devDependencies": {
     "gh-pages": "^1.1.0"

--- a/style-guide/src/pages/index.js
+++ b/style-guide/src/pages/index.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import Link from 'gatsby-link';
+
+import styles from '../styles/index.module.css';
+
+export default () => {
+  return (
+    <div className={styles.body}>
+      <h1>Hello world</h1>
+      <p>
+        <Link className={styles.link} to="/otkit-desktop-typography/">
+          link to otkit-desktop-typography
+        </Link>
+      </p>
+    </div>
+  );
+};

--- a/style-guide/src/pages/otkit-desktop-typography.js
+++ b/style-guide/src/pages/otkit-desktop-typography.js
@@ -1,0 +1,3 @@
+import React from "react";
+
+export default () => <div>Hello world!</div>;

--- a/style-guide/src/pages/otkit-desktop-typography.js
+++ b/style-guide/src/pages/otkit-desktop-typography.js
@@ -1,8 +1,16 @@
-import React from "react";
-import styles from "otkit-desktop-typography/token.common";
+import React from 'react';
+import Link from 'gatsby-link';
 
-export default () => (
-  <div>
-    Hello token! <pre>{JSON.stringify(styles, null, 2)}</pre>
-  </div>
-);
+import token from 'otkit-desktop-typography/token.common';
+import exampleStyle from '../styles/example.module.css';
+
+export default () => {
+  return (
+    <div>
+      <div className={exampleStyle.awesome}>
+        Hello token! <pre>{JSON.stringify(token, null, 2)}</pre>
+      </div>
+      <Link to="/">back to index</Link>
+    </div>
+  );
+};

--- a/style-guide/src/pages/otkit-desktop-typography.js
+++ b/style-guide/src/pages/otkit-desktop-typography.js
@@ -1,3 +1,8 @@
 import React from "react";
+import styles from "otkit-desktop-typography/token.common";
 
-export default () => <div>Hello world!</div>;
+export default () => (
+  <div>
+    Hello token! <pre>{JSON.stringify(styles, null, 2)}</pre>
+  </div>
+);

--- a/style-guide/src/styles/example.module.css
+++ b/style-guide/src/styles/example.module.css
@@ -1,0 +1,4 @@
+.awesome {
+  background: plum;
+  color: peachpuff;
+}

--- a/style-guide/src/styles/index.module.css
+++ b/style-guide/src/styles/index.module.css
@@ -1,0 +1,8 @@
+.body {
+  color: palegreen;
+}
+
+.link {
+  font-size: 20px;
+  color: paleturquoise;
+}


### PR DESCRIPTION
Closes #94 

This PR cover the following:
- [x] scaffhold a style-guide setup based around Gatsby as discussed on #94 
- [x] rely on lerna for the orchestration so that it can consume linked version of dependencies (OTKit,...)
- [x] `develop` mode to watch for files in all the tokens -> build them on change -> serve and hot-reload the style-guide at i.e `http://localhost:8000/otkit-desktop-typography`
- [x] gh-pages integration 
- [x] deploy still need to be tested and a post-publish hook to be set so that style-guide get deployed automatically everytime a token get published.
- grouping token to be discussed & implemented - for @karuto
- [x] first page to be updated (structure/design..) with some basic example for  @francesyun to work on  