### PR TITLE
[DX-400] Dependencies.io config

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,0 +1,15 @@
+collectors:
+
+  - type: js-npm
+    path: /
+    actors:
+    # pull requests for updates to any version
+    - type: js-npm
+      versions: "Y.Y.Y"
+  
+  - type: js-npm
+    path: packages/style-guide
+    actors:
+    # pull requests for updates to any version
+    - type: js-npm
+      versions: "Y.Y.Y"


### PR DESCRIPTION
Closes #98 

Added dependencies.io configured for this lerna monorepo so that we'll get PRs everytime a dependency could be updated, this allow us to keep the repo and the tools we use in it, up-to-date effortless