### PR TITLE
Fix reference to style guide js file

### DIFF
--- a/style-guide/src/pages/index.js
+++ b/style-guide/src/pages/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import fonts from '../styles/fonts.css';
 import styles from '../styles/index.module.css';
 import Colors from './otkit-colors.js';
-import Typography from './otkit-typography-desktop.js';
+import Typography from './otkit-typography.js';
 import Spacing from './otkit-spacing.js';
 import Borders from './otkit-borders.js';
 import Breakpoints from './otkit-breakpoints.js';


### PR DESCRIPTION
We are going to have platform switch support inside specific token files, so we are going to name this just a generic "typography" and later add more.