### PR TITLE
[DX-448] Group all the tokens references to a single file

### DIFF
--- a/style-guide/src/components/section-header/styles.module.css
+++ b/style-guide/src/components/section-header/styles.module.css
@@ -1,6 +1,4 @@
-@value spacing-large, spacing-medium from 'otkit-spacing/token.cssmodules.css';
-@value heading-large-font-size, heading-large-font-weight, heading-large-line-height from 'otkit-typography-desktop/token.cssmodules.css';
-@value color-gray-primary, color-gray-utility from 'otkit-colors/token.cssmodules.css';
+@value spacing-large, spacing-medium, heading-large-font-size, heading-large-font-weight, heading-large-line-height, color-gray-primary, color-gray-utility from '../../styles/tokens.module.css';
 
 .section-header {
   font-size: heading-large-font-size;

--- a/style-guide/src/styles/fonts.module.css
+++ b/style-guide/src/styles/fonts.module.css
@@ -1,4 +1,4 @@
-@value font-family-brand, font-weight-normal, font-weight-medium, font-weight-bold from 'otkit-typography-desktop/token.cssmodules.css';
+@value font-family-brand, font-weight-normal, font-weight-medium, font-weight-bold from './tokens.module.css';
 
 @font-face {
   font-family: font-family-brand;

--- a/style-guide/src/styles/index.module.css
+++ b/style-guide/src/styles/index.module.css
@@ -1,6 +1,4 @@
-@value spacing-medium, spacing-large, spacing-xlarge from 'otkit-spacing/token.cssmodules.css';
-@value color-primary, color-gray-primary from 'otkit-colors/token.cssmodules.css';
-@value font-family from 'otkit-typography-desktop/token.cssmodules.css';
+@value spacing-medium, spacing-large, spacing-xlarge, color-primary, color-gray-primary, font-family from './tokens.module.css';
 
 /* local variables */
 @value width-two-column: 992px;

--- a/style-guide/src/styles/otkit-colors.module.css
+++ b/style-guide/src/styles/otkit-colors.module.css
@@ -1,7 +1,4 @@
-@value spacing-xsmall, spacing-small, spacing-medium from 'otkit-spacing/token.cssmodules.css';
-@value font-size-xsmall, font-weight-medium from 'otkit-typography-desktop/token.cssmodules.css';
-@value border-radius-small from 'otkit-borders/token.cssmodules.css';
-@value color-gray-utility from 'otkit-colors/token.cssmodules.css';
+@value spacing-xsmall, spacing-small, spacing-medium, font-size-xsmall, font-weight-medium, border-radius-small, color-gray-utility from './tokens.module.css';
 
 .section-color {
   display: flex;

--- a/style-guide/src/styles/otkit-typography-desktop.module.css
+++ b/style-guide/src/styles/otkit-typography-desktop.module.css
@@ -1,4 +1,4 @@
-@value spacing-medium from 'otkit-spacing/token.cssmodules.css';
+@value spacing-medium from './tokens.module.css';
 
 .font-item {
   margin-bottom: spacing-medium;

--- a/style-guide/src/styles/tokens.module.css
+++ b/style-guide/src/styles/tokens.module.css
@@ -1,0 +1,4 @@
+@value border-radius-small from 'otkit-borders/token.cssmodules.css';
+@value color-gray-primary, color-gray-utility, color-primary from 'otkit-colors/token.cssmodules.css';
+@value spacing-large, spacing-medium, spacing-small, spacing-xlarge, spacing-xsmall from 'otkit-spacing/token.cssmodules.css';
+@value font-family, font-family-brand, font-size-xsmall, font-weight-bold, font-weight-medium, font-weight-normal, heading-large-font-size, heading-large-font-weight, heading-large-line-height from 'otkit-typography-desktop/token.cssmodules.css';


### PR DESCRIPTION
Closes #134 

Gatsby fails to compile the styleguide when referencing multiple times the css modules from different source with a `Error: Order in extracted chunk undefined` exception (only on build, not during develop).

The best way to fix it is to hook into the extract-text-webpack-plugin config and use the `ignoreOrder` option ([reference](https://github.com/webpack-contrib/extract-text-webpack-plugin#options)). Unfortunately, Gatsby still uses webpack 1 with an old version and the work towards webpack 3 (4?) is still ongoing: https://github.com/gatsbyjs/gatsby/projects/2

An hack that I found to avoid the issue to happen is by removing circular dependencies and just flattening the tree by having a single file referencing all the tokens, and then using that inside the various css modules. This seems to work fine and perhaps is not too bad while we wait for the gatsby v2 (which hopefully should solve this bug).