### PR TITLE
Update token.yml

### DIFF
--- a/OTKit/otkit-typography-desktop/token.yml
+++ b/OTKit/otkit-typography-desktop/token.yml
@@ -69,20 +69,6 @@ props:
     value: "24px"
 
 
-  # Design decisions for font group small-bold.
-  #
-  # =============================================
-  small-bold-font-size:
-    type: "size"
-    value: "16px"
-  small-bold-font-weight:
-    type: "raw"
-    value: "bold"
-  small-bold-line-height:
-    type: "size"
-    value: "24px"
-
-
   # Design decisions for font group small-medium.
   #
   # =============================================
@@ -93,20 +79,6 @@ props:
     type: "raw"
     value: "500"
   small-medium-line-height:
-    type: "size"
-    value: "24px"
-
-
-  # Design decisions for font group medium-regular.
-  #
-  # =============================================
-  medium-regular-font-size:
-    type: "size"
-    value: "18px"
-  medium-regular-font-weight:
-    type: "raw"
-    value: "normal"
-  medium-regular-line-height:
     type: "size"
     value: "24px"
 
@@ -137,20 +109,6 @@ props:
   large-bold-line-height:
     type: "size"
     value: "32px"
-
-
-  # Design decisions for font group xlarge-regular.
-  #
-  # =============================================
-  xlarge-regular-font-size:
-    type: "size"
-    value: "32px"
-  xlarge-regular-font-weight:
-    type: "raw"
-    value: "normal"
-  xlarge-regular-line-height:
-    type: "size"
-    value: "40px"
 
 
   # Design decisions for font group xlarge-bold.


### PR DESCRIPTION
Removed the additional styles for OTKit font groupings including:
small-bold
medium-regular
xlarge-regular

I think that there was some confusion for where these values were being used. Ping me if there is a problem and we will setup a brief meeting to align.