### PR TITLE
[DX-473] Auto-publish fails when there is a new token (fix)

### DIFF
--- a/utils/automatic-release/lib/installPackages.js
+++ b/utils/automatic-release/lib/installPackages.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const fs = require('fs-extra');
+const Promise = require('bluebird');
 const spawn = require('cross-spawn');
 
 // locally install latest version of packages
@@ -8,14 +9,14 @@ const installPackagesFromNPM = (packages, latestTemp) => {
   fs.ensureDirSync(latestTemp);
   fs.writeJsonSync(`${latestTemp}/package.json`, { name: 'release' });
 
-  return packages.map(pkg => {
+  return Promise.each(packages, pkg => {
     const cmd = spawn('npm', ['install', pkg], {
       stdio: 'inherit',
       cwd: latestTemp
     });
-    return new Promise(resolve => {
-      cmd.on('close', code => (code === 0 ? resolve(pkg) : resolve(null)));
-    });
+    return new Promise(resolve =>
+      cmd.on('close', code => resolve(code === 0 ? pkg : null))
+    );
   });
 };
 

--- a/utils/automatic-release/lib/process.js
+++ b/utils/automatic-release/lib/process.js
@@ -16,19 +16,20 @@ const latestTemp = path.join(__dirname, './tempNpm');
 const run = doPublish => {
   return new Promise((resolvePublish, rejectPublish) => {
     checkUpdated(root).then(updated => {
-      Promise.all(installPackages(updated, latestTemp))
+      installPackages(updated, latestTemp)
         .then(installed =>
           Promise.each(installed, pkg => {
             const { diff, version } = defineVersion(pkg, root, latestTemp);
+            const sep = '--------------------------------';
+            const printDiff = `${diff || '<DIFF NOT AVAILABLE>'}\n`;
+
             if (version) {
               if (doPublish) {
-                console.log(diff);
-                console.log('--------------------------------');
+                console.log(printDiff + sep);
                 return publishPackage(pkg, version, root);
               } else {
                 console.log(`TEST: "Should publish ${pkg} as ${version}"`);
-                console.log(diff);
-                console.log('--------------------------------');
+                console.log(printDiff + sep);
                 return Promise.resolve(pkg);
               }
             }

--- a/utils/automatic-release/lib/process.js
+++ b/utils/automatic-release/lib/process.js
@@ -20,16 +20,19 @@ const run = doPublish => {
         .then(installed =>
           Promise.each(installed, pkg => {
             const { diff, version } = defineVersion(pkg, root, latestTemp);
-            const sep = '--------------------------------';
-            const printDiff = `${diff || '<DIFF NOT AVAILABLE>'}\n`;
+            const printDiff = () =>
+              console.log(
+                `${diff ||
+                  '<DIFF NOT AVAILABLE>'}\n--------------------------------`
+              );
 
             if (version) {
               if (doPublish) {
-                console.log(printDiff + sep);
+                printDiff();
                 return publishPackage(pkg, version, root);
               } else {
                 console.log(`TEST: "Should publish ${pkg} as ${version}"`);
-                console.log(printDiff + sep);
+                printDiff();
                 return Promise.resolve(pkg);
               }
             }

--- a/utils/automatic-release/test/process.test.js
+++ b/utils/automatic-release/test/process.test.js
@@ -118,14 +118,11 @@ test('check updated', async () => {
 });
 
 test('install latest from NPM', async () => {
-  const installing = installLatestFromNPM(
+  const installed = installLatestFromNPM(
     ['ottheme-colors', 'otkit-borders'],
     './tempNpm'
   );
-  expect(await Promise.all(installing)).toEqual([
-    'ottheme-colors',
-    'otkit-borders'
-  ]);
+  expect(await installed).toEqual(['ottheme-colors', 'otkit-borders']);
 });
 
 test('automatic-release process', async () => {


### PR DESCRIPTION
1) When the token was unpublished, npm install would 404 and there would be a mess of events on the cmd.on('close') because of this: https://nodejs.org/api/child_process.html#child_process_event_close. More specifically *This is distinct from the 'exit' event, since multiple processes might share the same stdio streams*. The way I fixed it is by doing the same action is sequence.

2) There was also a "undefined" on the err diff, which I replaced with <DIFF NOT AVAILABLE> which is imho cleaner.