### PR TITLE
Update color naming

### DIFF
--- a/OTKit/otkit-colors/token.yml
+++ b/OTKit/otkit-colors/token.yml
@@ -2,29 +2,29 @@ props:
   # Primary Action
   # This color is only used on objects, backgrounds with large text (24px or larger, bold), and will be used as a color to guide users towards actionable content.
   # =============================================
-  color-primary:
+  color-brand:
     value: "#da3743"
   color-primary-active:
     value: "#b8222d"
 
   # Primary Gray, used on all text sizes
   # =============================================
-  color-gray-primary:
+  color-neutral-2:
     value: "#2d333f"
 
   # Secondary Gray, used on smaller font sizes and for disabled primary buttons
   # =============================================
-  color-gray-secondary:
+  color-neutral-3:
     value: "#6f737b"
 
   # Utility Gray, used for borders, dividers, containers
   # =============================================
-  color-gray-utility:
+  color-neutral-4:
     value: "#d8d9db"
 
   # Lightest gray, used for backgrounds for the page and backgrounds for active/hover states
   # =============================================
-  color-gray-active:
+  color-neutral-5:
     value: "#f1f2f4"
 
   # White, used for button text and (if necessary) backgrounds


### PR DESCRIPTION
I've changed the naming conventions to broader terms. I'll be working on documentation that will include definition of where and how to use the color (similar to what is already listed). 

Pro:
Flexibility
Non-functional

Con:
Vague

Note:
Design will be very tight on color. Don't expect these to change often, if ever. If they do, the intent is to swap Hex Values, not create new colors and names and replace them.

If my proposal is "too" vague adding another layer of context is low impact to design and easy to update. Examples below. 

I'll also add, that I don't think that this is a heavy-weighted design decision here. On the design side we'll be more likely than not be talking about them with literal hex values or functionally (ex. use #2d333f for text).

----------------------------------------------------

Alternative approaches, example:
(color-neutral-1 =) **lightest-gray**
(color-neutral-2 =) **lighter-gray**
(color-neutral-3 =) **light-gray**
(color-neutral-4 =) **dark-gray**
(color-neutral-5 =) **darker-gray**
(color-neutral-6 =) **darkest-gray**

or

(color-neutral-1 =) **light-gray-1**
(color-neutral-2 =) **light-gray-2**
(color-neutral-3 =) **medium-gray-1**
(color-neutral-4 =) **medium-gray-2**
(color-neutral-5 =) **dark-gray-1**
(color-neutral-6 =) **dark-gray-2**