### PR TITLE
[breaking change] new colors; fix styleguide

### DIFF
--- a/OTKit/otkit-colors/token.yml
+++ b/OTKit/otkit-colors/token.yml
@@ -1,36 +1,201 @@
 props:
-  # Primary Action
-  # This color is only used on objects, backgrounds with large text (24px or larger, bold), and will be used as a color to guide users towards actionable content.
-  # =============================================
-  color-primary:
-    value: "#da3743"
-  color-primary-active:
-    value: "#b8222d"
-
-  # Primary Gray, used on all text sizes
-  # =============================================
-  color-gray-primary:
-    value: "#2d333f"
-
-  # Secondary Gray, used on smaller font sizes and for disabled primary buttons
-  # =============================================
-  color-gray-secondary:
-    value: "#6f737b"
-
-  # Utility Gray, used for borders, dividers, containers
-  # =============================================
-  color-gray-utility:
-    value: "#d8d9db"
-
-  # Lightest gray, used for backgrounds for the page and backgrounds for active/hover states
-  # =============================================
-  color-gray-active:
+  ash-lightest:
     value: "#f1f2f4"
 
-  # White, used for button text and (if necessary) backgrounds
-  # =============================================
-  color-white:
-    value: "#FFF"
+  ash-lighter:
+    value: "#d8d9db"
+
+  ash-light:
+    value: "#91949a"
+
+  ash:
+    value: "#6f737b"
+
+  ash-dark:
+    value: "#2d333f"
+
+  ash-darker:
+    value: "#141a26"
+
+  red-lightest:
+    value: "#fceeef"
+
+  red-lighter:
+    value: "#eea0a5"
+
+  red-light:
+    value: "#e15b64"
+
+  red:
+    value: "#da3743"
+
+  red-dark:
+    value: "#931b23"
+
+  red-darker:
+    value: "#450d10"
+
+  aqua-lightest:
+    value: "#eefcf9"
+
+  aqua-lighter:
+    value: "#3ddbb6"
+
+  aqua-light:
+    value: "#1fa888"
+
+  aqua:
+    value: "#18856b"
+
+  aqua-dark:
+    value: "#0c4134"
+
+  aqua-darker:
+    value: "#09342a"
+
+  blue-lightest:
+    value: "#eef1fc"
+
+  blue-lighter:
+    value: "#b1c1f1"
+
+  blue-light:
+    value: "#6c8ae4"
+
+  blue:
+    value: "#4a6fde"
+
+  blue-dark:
+    value: "#2146b5"
+
+  blue-darker:
+    value: "#0d1b45"
+
+  fuschia-lightest:
+    value: "#fceef5"
+
+  fuschia-lighter:
+    value: "#eb93bf"
+
+  fuschia-light:
+    value: "#df4e96"
+
+  fuschia:
+    value: "#d82c82"
+
+  fuschia-dark:
+    value: "#971c59"
+
+  fuschia-darker:
+    value: "#450d29"
+
+  green-lightest:
+    value: "#f0faf3"
+
+  green-lighter:
+    value: "#64c987"
+
+  green-light:
+    value: "#39a25e"
+
+  green:
+    value: "#2f864d"
+
+  green-dark:
+    value: "#194829"
+
+  green-darker:
+    value: "#153c23"
+
+  orange-lightest:
+    value: "#fcf1ee"
+
+  orange-lighter:
+    value: "#e69b84"
+
+  orange-light:
+    value: "#d86441"
+
+  orange:
+    value: "#c84f29"
+
+  orange-dark:
+    value: "#83331b"
+
+  orange-darker:
+    value: "#441a0e"
+
+  purple-lightest:
+    value: "#f8f0fa"
+
+  purple-lighter:
+    value: "#d7a7e2"
+
+  purple-light:
+    value: "#bb6acd"
+
+  purple:
+    value: "#ad4cc3"
+
+  purple-dark:
+    value: "#7c2f8e"
+
+  purple-darker:
+    value: "#36143d"
+
+  teal-lightest:
+    value: "#eef8fb"
+
+  teal-lighter:
+    value: "#61bddb"
+
+  teal-light:
+    value: "#2b9abf"
+
+  teal:
+    value: "#247f9e"
+
+  teal-dark:
+    value: "#154a5b"
+
+  teal-darker:
+    value: "#0f3643"
+
+  violet-lightest:
+    value: "#f1edfc"
+
+  violet-lighter:
+    value: "#d5c9f7"
+
+  violet-light:
+    value: "#9d82ed"
+
+  violet:
+    value: "#7f5ce8"
+
+  violet-dark:
+    value: "#4d1fd6"
+
+  violet-darker:
+    value: "#1a0a47"
+
+  yellow-lightest:
+    value: "#fff8eb"
+
+  yellow-lighter:
+    value: "#fdc958"
+
+  yellow-light:
+    value: "#fdaf08"
+
+  yellow:
+    value: "#d99502"
+
+  yellow-dark:
+    value: "#885e01"
+
+  yellow-darker:
+    value: "#513701"
 
 global:
   platform: "core"

--- a/style-guide/src/components/section-header/styles.module.css
+++ b/style-guide/src/components/section-header/styles.module.css
@@ -1,11 +1,12 @@
-@value spacing-large, spacing-medium, large-bold-font-size, large-bold-font-weight, large-bold-line-height, color-gray-primary, color-gray-utility from '../../styles/tokens.module.css';
+@value spacing-large, spacing-medium, large-bold-font-size, large-bold-font-weight, large-bold-line-height from '../../styles/tokens.module.css';
+@value ash-lighter, ash-dark from 'otkit-colors/token.cssmodules.css';
 
 .section-header {
-  font-size: large-font-size;
+  font-size: large-bold-font-size;
   font-weight: large-bold-font-weight;
-  line-height: large-line-height;
-  color: color-gray-primary;
-  border-bottom: 1px solid color-gray-utility;
+  line-height: large-bold-line-height;
+  color: ash-dark;
+  border-bottom: 1px solid ash-lighter;
   padding-bottom: spacing-medium;
   margin: 0 0 spacing-medium 0;
   display: flex;

--- a/style-guide/src/pages/otkit-colors.js
+++ b/style-guide/src/pages/otkit-colors.js
@@ -18,29 +18,51 @@ const textColor = hex => {
 };
 
 const Colors = () => {
-  var tokens = _.toPairsIn(token);
-
-  tokens = tokens.map((token, index) => {
-    const rgb = token[1];
-    const colorBlock =
-      chroma.contrast(rgb, 'white') > 4 ? 'color-block' : 'color-block-border';
-    return (
-      <div className={styles['card']} key={index}>
-        <div
-          className={styles[colorBlock]}
-          style={{ backgroundColor: rgb, color: textColor(rgb) }}
-        >
-          <div className={styles['color-hex']}>{chroma(rgb).hex()}</div>
-          <div className={styles['color-rgb']}>{rgb}</div>
-        </div>
-        <div className={styles['color-name']}>{_.kebabCase(token[0])}</div>
-      </div>
-    );
+  /* find all the base colors, then display their derived colors in groups,
+   by color. */
+  const baseColors = _.pickBy(token, (value, key) => {
+    return _.kebabCase(key).indexOf('-') == -1;
   });
+
+  const groups = _.map(baseColors, (value, key) => {
+    const relatedColors = _.pickBy(token, (val, proposedKey) => {
+      return proposedKey.indexOf(key) != -1;
+    });
+
+    const tokens = _.toPairsIn(relatedColors)
+      .sort((left, right) => {
+        return chroma(left[1]).luminance() - chroma(right[1]).luminance();
+      })
+      .map((token, index) => {
+        const rgb = token[1];
+        const name = token[0];
+
+        const colorBlock =
+          chroma.contrast(rgb, 'white') > 4
+            ? 'color-block'
+            : 'color-block-border';
+
+        return (
+          <div className={styles['card']} key={index}>
+            <div
+              className={styles[colorBlock]}
+              style={{ backgroundColor: rgb, color: textColor(rgb) }}
+            >
+              <div className={styles['color-hex']}>{chroma(rgb).hex()}</div>
+              <div className={styles['color-rgb']}>{rgb}</div>
+            </div>
+            <div className={styles['color-name']}>{_.kebabCase(name)}</div>
+          </div>
+        );
+      });
+
+    return <div className={styles['section-color']}>{tokens}</div>;
+  });
+
   return (
     <section>
       <SectionHeader text="Colors" />
-      <div className={styles['section-color']}>{tokens}</div>
+      {groups.map((group, index) => <div key={index}>{group}</div>)}
     </section>
   );
 };

--- a/style-guide/src/styles/index.module.css
+++ b/style-guide/src/styles/index.module.css
@@ -1,4 +1,5 @@
-@value color-gray-primary, color-primary, font-family, medium-bold-font-size, medium-bold-font-weight, medium-bold-line-height, spacing-medium, spacing-large, spacing-xlarge from './tokens.module.css';
+@value font-family, medium-bold-font-size, medium-bold-font-weight, medium-bold-line-height, spacing-medium, spacing-large, spacing-xlarge from './tokens.module.css';
+@value ash-dark, red from 'otkit-colors/token.cssmodules.css';
 
 /* local variables */
 @value width-two-column: 992px;
@@ -7,12 +8,12 @@
 
 body {
   font-family: font-family;
-  color: color-gray-primary;
+  color: ash-dark;
 }
 
 a {
   text-decoration: none;
-  color: color-primary;
+  color: red;
 }
 
 .two-column {
@@ -33,8 +34,8 @@ a {
 }
 
 .nav-link .link-active {
-  color: color-primary;
-  border-bottom: 2px solid color-primary;
+  color: red;
+  border-bottom: 2px solid red;
 }
 
 .main {
@@ -44,7 +45,7 @@ a {
 
 .link-secondary,
 .nav-link a {
-  color: color-gray-primary;
+  color: ash-dark;
 }
 
 section {

--- a/style-guide/src/styles/otkit-colors.module.css
+++ b/style-guide/src/styles/otkit-colors.module.css
@@ -1,46 +1,49 @@
-@value spacing-xsmall, spacing-small, spacing-medium, font-size-xsmall, font-weight-medium, border-radius-small, color-gray-utility from './tokens.module.css';
+@value spacing-xsmall, spacing-small, spacing-medium, spacing-xlarge, xsmall-regular-font-size, xsmall-regular-font-weight, xsmall-regular-line-height, xsmall-medium-font-size, xsmall-medium-font-weight, xsmall-medium-line-height, border-radius-small from './tokens.module.css';
+@value ash-lighter from 'otkit-colors/token.cssmodules.css';
 
 .section-color {
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
-  &:after {
-    content: "";
-    width: 23%;
-  }
 }
 
 .card {
   text-align: center;
-  width: 23%;
+  width: 16%;
   margin-bottom: spacing-medium;
 }
 
 .color-block {
   border-radius: border-radius-small;
   padding: spacing-medium 0;
-  text-align: center;
+  height: calc(xsmall-medium-line-height * 2 + spacing-xsmall * 2 + xsmall-regular-line-height);
 }
 
 .color-block-border {
   composes: color-block;
-  border: 1px solid color-gray-utility;
+  border: 1px solid ash-lighter;
 }
 
 .color-name {
-  border: 1px solid color-gray-utility;
-  font-size: font-size-xsmall;
+  border: 1px solid ash-lighter;
+  font-size: xsmall-regular-font-size;
+  font-weight: xsmall-regular-font-weight;
+  line-height: xsmall-regular-line-height;
   padding: spacing-xsmall;
   margin: spacing-small 0;
 }
 
 .color-hex {
-  font-weight: font-weight-medium;
+  font-size: xsmall-medium-font-size;
+  font-weight: xsmall-medium-font-weight;
+  line-height: xsmall-medium-line-height;
   text-transform: uppercase;
 }
 
 .color-rgb {
-  font-size: font-size-xsmall;
+  font-size: xsmall-regular-font-size;
+  font-weight: xsmall-regular-font-weight;
+  line-height: xsmall-regular-line-height;
   opacity: .7;
   margin: spacing-xsmall 0;
 }

--- a/style-guide/src/styles/otkit-icons.module.css
+++ b/style-guide/src/styles/otkit-icons.module.css
@@ -1,4 +1,5 @@
-@value spacing-xsmall, spacing-small, spacing-medium, font-size-xsmall, border-radius-small, color-gray-utility from './tokens.module.css';
+@value spacing-xsmall, spacing-small, spacing-medium, xsmall-regular-line-height, xsmall-regular-font-size, xsmall-regular-font-weight, border-radius-small from './tokens.module.css';
+@value ash-lighter from 'otkit-colors/token.cssmodules.css';
 
 .section-icon {
   display: flex;
@@ -25,8 +26,10 @@
 }
 
 .icon-name {
-  border: 1px solid color-gray-utility;
-  font-size: font-size-xsmall;
+  border: 1px solid ash-lighter;
+  font-size: xsmall-regular-font-size;
+  font-weight: xsmall-regular-font-weight;
+  line-height: xsmall-regular-line-height;
   padding: spacing-xsmall;
   margin: spacing-small 0;
 }

--- a/style-guide/src/styles/tokens.module.css
+++ b/style-guide/src/styles/tokens.module.css
@@ -1,4 +1,3 @@
 @value border-radius-small from 'otkit-borders/token.cssmodules.css';
-@value color-gray-primary, color-gray-utility, color-primary from 'otkit-colors/token.cssmodules.css';
 @value spacing-large, spacing-medium, spacing-small, spacing-xlarge, spacing-xsmall from 'otkit-spacing/token.cssmodules.css';
-@value font-family, font-family-brand, font-size-xsmall, font-weight-bold, font-weight-medium, font-weight-normal, medium-bold-font-size, medium-bold-font-weight, medium-bold-line-height from 'otkit-typography-desktop/token.cssmodules.css';
+@value font-family, font-family-brand, font-weight-normal, font-weight-medium, font-weight-bold, xsmall-regular-font-size, xsmall-regular-font-weight, xsmall-regular-line-height, xsmall-medium-font-size, xsmall-medium-font-weight, xsmall-medium-line-height, medium-bold-font-size, medium-bold-font-weight, medium-bold-line-height, large-bold-font-size, large-bold-font-weight, large-bold-line-height from 'otkit-typography-desktop/token.cssmodules.css';


### PR DESCRIPTION
1. Implement the new colors, as per design. This adds colors that are named by content, not by intent. There is a mapping of old to new colors, which I will add to a comment below this PR description.
2. Group the colors by their base color.
3. Fix all the incorrect references to token values that were renamed, lost, changed, etc. In particular `typography` stuff was renamed and no one fixed the styleguide.

I want to figure out a way to throw errors when building for the variables thing, but I'll do that in a follow up PR.