### PR TITLE
fix version of otkit-icons to match what is published

### DIFF
--- a/OTKit/otkit-icons/package.json
+++ b/OTKit/otkit-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "otkit-icons",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "OpenTable icons design token",
   "author": {
     "email": "design-tokens@opentable.com"


### PR DESCRIPTION
So the version that is published is 3.0.0 (as well as 2.1.0), but because of racing, the actual package.json wasn't updated, so... updating it manually to 3. As this merges, it should bump to 3.1.0 - I think - based on what has changed. The failed publishes in master are trying to do a minor bump right now.

the next icon PR #229 will be a breaking change without actual content changing, so I will manually bump to 4.0.0 and publish that manually, and then we should be back to normal with autopublishes.