### PR TITLE
fix styleguide build for v3 icons

### DIFF
--- a/style-guide/package.json
+++ b/style-guide/package.json
@@ -22,7 +22,7 @@
     "otkit-borders": "^1.0.3",
     "otkit-breakpoints": "^4.0.2",
     "otkit-colors": "^3.0.1",
-    "otkit-icons": "^2.0.0",
+    "otkit-icons": "^3.0.0",
     "otkit-shadows": "^1.0.3",
     "otkit-spacing": "^2.0.3",
     "otkit-typography-desktop": "^2.0.0"


### PR DESCRIPTION
Fix the styleguide dependency with a major bump to get the styleguide to build properly so the automation is green. Prepares us to go to v4.