### PR TITLE
only generate commonjs for otkit-icons for now

### DIFF
--- a/OTKit/otkit-icons/package.json
+++ b/OTKit/otkit-icons/package.json
@@ -18,8 +18,7 @@
   },
   "files": [
     "package.json",
-    "token.cssmodules.css",
-    "token.scss",
-    "token.yml"
+    "token.yml",
+    "token.common.js"
   ]
 }


### PR DESCRIPTION
cc @jrolfs @acolchado @karuto 

So, I was about to publish otkit-icons@4.0.0, when I discovered - by luckily hand running dry-run publish - that we are not publishing the commonjs.

Also, I notice that the cssmodule and SASS versions of the icons would have a giant full SVG XML markup, without enclosing `"` quotes.

For now, I would like to move forward by only outputting commonjs, and not the other versions for now. We can support the other versions in a patch followup by customizing the output to be a data-uri via adding custom code to the theo generation.

Right now, the build steps are still disabled in travis. We should merge this to master, then I can publish v4 and then push the tags and commit to master, and then reenable the build.

