### PR TITLE
Add xxsmall-regular aka footnote typography grouping

### DIFF
--- a/OTKit/otkit-typography-desktop/token.yml
+++ b/OTKit/otkit-typography-desktop/token.yml
@@ -27,6 +27,21 @@ props:
     value: "'BrandonText', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'"
 
 
+  # Design decisions for font group xxsmall-regular.
+  # WARNING: This should only be used for footnotes.
+  #
+  # =============================================
+  xxsmall-regular-font-size:
+    type: "size"
+    value: "12px"
+  xxsmall-regular-font-weight:
+    type: "raw"
+    value: "normal"
+  xxsmall-regular-line-height:
+    type: "size"
+    value: "16px"
+
+
   # Design decisions for font group xsmall-medium.
   #
   # =============================================


### PR DESCRIPTION
This new grouping is added based on @mannionaco's latest spec. We may change the name later. This will also get the auto publishing bot to rebuild the typography-desktop token and fix the empty package bug we had with version 3.0.0.