### PR TITLE
Revert "Update gatsby in style-guide/package.json from ^1.9.199 to ^2.0.44"

### DIFF
--- a/style-guide/package.json
+++ b/style-guide/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "chroma-js": "^1.3.6",
-    "gatsby": "^2.0.44",
+    "gatsby": "^1.9.199",
     "gatsby-link": "^1.6.36",
     "lodash": "^4.17.5",
     "otkit-borders": "^1.0.3",


### PR DESCRIPTION
Reverts opentable/design-tokens#333, which broke **master**

![https://media.giphy.com/media/vX9WcCiWwUF7G/giphy.gif](https://media.giphy.com/media/vX9WcCiWwUF7G/giphy.gif)