### PR TITLE
Add @ot-react-ui/typography-desktop to Design Bar

### DIFF
--- a/style-guide/src/pages/otkit-typography.js
+++ b/style-guide/src/pages/otkit-typography.js
@@ -32,6 +32,20 @@ const TypographyDesktop = () => {
   return (
     <div className={styles['main-container']}>
       <SectionHeader text="Typography – Desktop" type="SectionHeader__small" />
+      <p>
+        To use these OTKit typography rules in your project, we have a
+        production-tested pacakge that exports readily made font groupings for
+        you:{' '}
+        <a href="https://github.com/opentable/ot-react-ui-components/tree/master/styles/typography-desktop">
+          @ot-react-ui/typography-desktop.
+        </a>{' '}
+        See its README for details.
+      </p>
+      <p>
+        It is generally <em>not recommended</em> to directly consume / reference
+        the values in this token unless for explicit reasons, such as
+        overriding.
+      </p>
       <div className={styles['font-column']}>{groups}</div>
     </div>
   );


### PR DESCRIPTION
This PR adds a paragraph advertising `@ot-react-ui/typography-desktop` package for the potential consumers of the `typography-desktop` token.

![image](https://user-images.githubusercontent.com/1095291/49834464-4ebd3080-fd51-11e8-94ea-5a76f2e2f01f.png)
