### PR TITLE
Update otkit-typography-desktop in style-guide/package.json from ^2.0.0 to ^3.1.0

### DIFF
--- a/style-guide/package.json
+++ b/style-guide/package.json
@@ -25,6 +25,6 @@
     "otkit-icons": "^4.0.0",
     "otkit-shadows": "^1.0.3",
     "otkit-spacing": "^2.0.3",
-    "otkit-typography-desktop": "^2.0.0"
+    "otkit-typography-desktop": "^3.1.0"
   }
 }


### PR DESCRIPTION
This PR updates the Design Bar style guide typography section to the latest version.

![image](https://user-images.githubusercontent.com/1095291/50256486-5f9e1f80-03ab-11e9-9f47-f641c277a84d.png)
