### PR TITLE
Update fuchsia typo

### DIFF
--- a/OTKit/otkit-colors/token.yml
+++ b/OTKit/otkit-colors/token.yml
@@ -53,22 +53,22 @@ props:
   blue-darker:
     value: "#0d1b45"
 
-  fuschia-lightest:
+  fuchsia-lightest:
     value: "#fceef5"
 
-  fuschia-lighter:
+  fuchsia-lighter:
     value: "#eb93bf"
 
-  fuschia-light:
+  fuchsia-light:
     value: "#df4e96"
 
-  fuschia:
+  fuchsia:
     value: "#d82c82"
 
-  fuschia-dark:
+  fuchsia-dark:
     value: "#971c59"
 
-  fuschia-darker:
+  fuchsia-darker:
     value: "#450d29"
 
   green-lightest:


### PR DESCRIPTION
As #255 pointed out, we spelled "fuchsia" wrong for the longest time. This corrects it, but I would like to make sure that we spell it right in the design tools as well. @mannionaco 

This will be a breaking change, requiring a major version update.