### PR TITLE
Update Design Bar to use latest otkit-icons v7 and otkit-colors v4

### DIFF
--- a/style-guide/package.json
+++ b/style-guide/package.json
@@ -22,7 +22,7 @@
     "otkit-borders": "^1.0.3",
     "otkit-breakpoints": "^4.0.2",
     "otkit-colors": "^3.0.1",
-    "otkit-icons": "^4.0.0",
+    "otkit-icons": "^7.0.0",
     "otkit-shadows": "^1.0.3",
     "otkit-spacing": "^2.0.3",
     "otkit-typography-desktop": "^3.1.0"

--- a/style-guide/package.json
+++ b/style-guide/package.json
@@ -21,7 +21,7 @@
     "lodash": "^4.17.5",
     "otkit-borders": "^1.0.3",
     "otkit-breakpoints": "^4.0.2",
-    "otkit-colors": "^3.0.1",
+    "otkit-colors": "^4.0.0",
     "otkit-icons": "^7.0.0",
     "otkit-shadows": "^1.0.3",
     "otkit-spacing": "^2.0.3",


### PR DESCRIPTION
The current style guide is outdated when it comes to icons & colors. This brings it up to spec.

cc @mannionaco @benaz23 🙇 