### PR TITLE
feat(otkit-icons): adds optimization for SVG paths and transforms

### DIFF
--- a/utils/build-icons/lib/config.js
+++ b/utils/build-icons/lib/config.js
@@ -57,7 +57,7 @@ module.exports = {
         convertPathData: true
       },
       {
-        convertTransform: false
+        convertTransform: true
       },
       {
         removeUnknownsAndDefaults: true

--- a/utils/build-icons/lib/config.js
+++ b/utils/build-icons/lib/config.js
@@ -54,7 +54,7 @@ module.exports = {
         convertColors: true
       },
       {
-        convertPathData: false
+        convertPathData: true
       },
       {
         convertTransform: false


### PR DESCRIPTION
This PR is to toggle a couple of option for `svgo` to optimize the path and transform data with smart/precision rounding.

Two reasons for this optimization:
- reduces file size
- optimizes the data

**Is it a breaking change?**
Technically, it is a breaking change. The path and transform data are updated, rounded and refactored. However from visual inspections, the icons are identical. 

**Examples of the options toggled:**

Path data:

```javascript
// With convertPathData off
<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><g
      id="icon/ic_accessibility" fill="none" fill-rule="evenodd"><path
      d="M15.7966749,15.3955021 C15.860534,15.4518057 15.9202011,15.5135792
      15.9749283,15.580468 L19.5479146,19.9474512 C19.8402708,20.3047754
      20,20.752242 20,21.2139268 L20,21.25 C20,21.6642136 19.6642136,22 19.25,22
      C18.7753012,22 18.3256689,21.7869286 18.0250717,21.419532
      L14.4520854,17.0525488 C14.4379246,17.0352412 14.4240749,17.017722
      14.4105395,17 L11,17 C10.4477153,17 10,16.5522847 10,16 L10,12
      C10,11.4477153 10.4477153,11 11,11 L15,11 C15.5522847,11 16,11.4477153
      16,12 C16,12.5522847 15.5522847,13 15,13 L12,13 L12,15 L15,15
      C15.3251396,15 15.6140367,15.1551728 15.7966749,15.3955021 Z M8,10.3414114
      L8,12.5351288 C6.80439726,13.2267476 6,14.5194353 6,16 C6,18.209139
      7.790861,20 10,20 C11.1045695,20 12.1045695,19.5522847
      12.8284271,18.8284271 L14.2426407,20.2426407 C13.1568542,21.3284271
      11.6568542,22 10,22 C6.6862915,22 4,19.3137085 4,16 C4,13.3875623
      5.66961525,11.1650842 8,10.3414114 Z M11,10 C8.790861,10 7,8.209139 7,6
      C7,3.790861 8.790861,2 11,2 C13.209139,2 15,3.790861 15,6 C15,8.209139
      13.209139,10 11,10 Z M11,8 C12.1045695,8 13,7.1045695 13,6 C13,4.8954305
      12.1045695,4 11,4 C9.8954305,4 9,4.8954305 9,6 C9,7.1045695 9.8954305,8
      11,8 Z" id="ic_accessibility" fill="#2D333F"/></g></svg>

// With convertPathData on
<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><g
      id="icon/ic_accessibility" fill="none" fill-rule="evenodd"><path
      d="M15.797 15.396c.064.056.123.118.178.184l3.573 4.367A2 2 0 0 1 20
      21.214v.036a.75.75 0 0 1-.75.75c-.475
      0-.924-.213-1.225-.58l-3.573-4.367a2.001 2.001 0 0 1-.041-.053H11a1 1 0 0
      1-1-1v-4a1 1 0 0 1 1-1h4a1 1 0 0 1 0 2h-3v2h3c.325 0 .614.155.797.396zM8
      10.34v2.194a4 4 0 1 0 4.828 6.293l1.415 1.415A6 6 0 1 1 8 10.342zM11 10a4
      4 0 1 1 0-8 4 4 0 0 1 0 8zm0-2a2 2 0 1 0 0-4 2 2 0 0 0 0 4z"
      id="ic_accessibility" fill="#2D333F"/></g></svg>
```

Transform:

```javascript
// With convertTransform off
 <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><g
      id="icon/ic_advance" fill="none" fill-rule="evenodd"><path
      d="..." id="ic_advance"
      fill="#2D333F" transform="translate(10.656854, 11.656854) scale(-1, 1)
      rotate(-45.000000) translate(-10.656854, -11.656854)"/></g></svg>

// With convertTransform on
<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><g
      id="icon/ic_advance" fill="none" fill-rule="evenodd"><path
      d="..." id="ic_advance" fill="#2D333F"
      transform="scale(-1 1) rotate(-45 0 37.385)"/></g></svg>
```