### PR TITLE
fix(otkit-typography-desktop): BUF-48 updates large and xlarge bold font sizes

### DIFF
--- a/OTKit/otkit-typography-desktop/token.yml
+++ b/OTKit/otkit-typography-desktop/token.yml
@@ -161,7 +161,7 @@ props:
   # =============================================
   large-bold-font-size:
     type: "size"
-    value: "22px"
+    value: "24px"
   large-bold-font-weight:
     type: "raw"
     value: "bold"
@@ -175,7 +175,7 @@ props:
   # =============================================
   xlarge-bold-font-size:
     type: "size"
-    value: "28px"
+    value: "32px"
   xlarge-bold-font-weight:
     type: "raw"
     value: "bold"


### PR DESCRIPTION
This PR updating the two font sets: `large-bold` and `xlarge-bold` to reflect to the new OTKit changes.

The fonts updates:
`large-bold` from `22px` to `24px`
`xlarge-bold` from `28px` to `32px`

Line heights and font weights remain the same.

This is a `patch` upgrade unless we need to go minor.

Jira ticket: [BUF-48](https://opentable.atlassian.net/browse/BUF-48)