### PR TITLE
fix(otkit-icons): include css modules file

### DIFF
--- a/OTKit/otkit-icons/package.json
+++ b/OTKit/otkit-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "otkit-icons",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "description": "OpenTable icons design token",
   "author": {
     "email": "design-tokens@opentable.com"
@@ -20,6 +20,7 @@
     "package.json",
     "token.yml",
     "token.scss",
+    "token.cssmodules.css",
     "token.common.js"
   ],
   "main": "token.common.js"


### PR DESCRIPTION
This PR is to include the icon token support for css modules. Somehow we have been publishing the NPM packages to include common js and scss only. This has been happening for a while now because Travis build always output false positives on the builds.

[https://api.travis-ci.org/v3/job/675835661/log.txt](https://api.travis-ci.org/v3/job/675835661/log.txt)

The css modules was ignore because npmjs is using `gitignore` as substitute.
[https://docs.npmjs.com/files/package.json#files](https://docs.npmjs.com/files/package.json#files)
