### PR TITLE
fix(styleguide): bumps version for styleguide otkit-icons

### DIFF
--- a/style-guide/package.json
+++ b/style-guide/package.json
@@ -23,7 +23,7 @@
     "otkit-breakpoints": "^4.0.2",
     "otkit-colors": "^4.0.0",
     "otkit-grids": "^1.0.0",
-    "otkit-icons": "^7.0.0",
+    "otkit-icons": "^8.3.0",
     "otkit-shadows": "^1.0.3",
     "otkit-spacing": "^2.0.3",
     "otkit-typography-desktop": "^3.1.0"


### PR DESCRIPTION
This PR is bumping the version for `otkit-icons`. I am trying to resolve the older package which is trying to look for the cssmodules and it does not exist in previous versions