### PR TITLE
feat(styleguide): adds themeable icon styleguide

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The `otkit-icons` token offers two different sets of icons:
 
 They are available for SCSS, CSS Modules and CommonJS
 
-*Note: The themeable icons are only available in version `9.1.0` and above*
+*Note: The themeable icons are only available in version `9.0.1` and above*
 
 #### Standard icons
 

--- a/style-guide/package.json
+++ b/style-guide/package.json
@@ -1,7 +1,7 @@
 {
   "name": "style-guide",
   "private": true,
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Static Style Guide for OpenTable's Design-Tokens",
   "license": "MIT",
   "repository": {
@@ -23,9 +23,9 @@
     "otkit-breakpoints": "^4.0.2",
     "otkit-colors": "^4.0.0",
     "otkit-grids": "^1.0.0",
-    "otkit-icons": "^9.0.0",
+    "otkit-icons": "^9.0.1",
     "otkit-shadows": "^1.0.3",
-    "otkit-spacing": "^2.0.3",
-    "otkit-typography-desktop": "^3.1.0"
+    "otkit-spacing": "^2.1.0",
+    "otkit-typography-desktop": "^3.3.0"
   }
 }

--- a/style-guide/src/components/section-header/index.js
+++ b/style-guide/src/components/section-header/index.js
@@ -1,16 +1,19 @@
 import React from 'react';
 import styles from './styles.module.css';
 
-export default function SectionHeader({ text, type }) {
+export default function SectionHeader({ text, type, content }) {
   return (
-    <h2
-      className={
-        type === 'SectionHeader__small'
-          ? styles['section-header-small']
-          : styles['section-header']
-      }
-    >
-      {text}
-    </h2>
+    <div className={styles['section-container']}>
+      <h2
+        className={
+          type === 'SectionHeader__small'
+            ? styles['section-header-small']
+            : styles['section-header']
+        }
+      >
+        {text}
+      </h2>
+      {content && <div className={styles['section-content']}>{content}</div>}
+    </div>
   );
 }

--- a/style-guide/src/components/section-header/styles.module.css
+++ b/style-guide/src/components/section-header/styles.module.css
@@ -6,14 +6,26 @@
   font-weight: xlarge-bold-font-weight;
   line-height: xlarge-bold-line-height;
   color: ash-dark;
-  border-bottom: 1px solid ash-lighter;
-  padding-bottom: spacing-medium;
-  margin: 0 0 spacing-medium 0;
-  display: flex;
-  justify-content: space-between;
+  margin: 0;
+  flex: 1;
 }
 
 .section-header-small {
 	composes: section-header;
 	font-size: large-bold-font-size;
+}
+
+.section-container {
+  border-bottom: 1px solid ash-lighter;
+  padding-bottom: spacing-medium;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  margin-bottom: spacing-medium;
+}
+
+.section-content {
+  flex: 1;
+  display: flex;
+  justify-content: flex-end;
 }

--- a/style-guide/src/layouts/index.js
+++ b/style-guide/src/layouts/index.js
@@ -36,7 +36,7 @@ export default ({ children }) => (
         </li>
         <li>
           <Link to="/data/getting-started" className={styles['header-link']}>
-             Data
+            Data
           </Link>
         </li>
         <li>
@@ -63,6 +63,7 @@ export default ({ children }) => (
           <NavLink to="/otkit-breakpoints/">Breakpoints</NavLink>
           <NavLink to="/otkit-shadows/">Shadows</NavLink>
           <NavLink to="/otkit-icons/">Icons</NavLink>
+          <NavLink to="/otkit-icons-theme/">Icons (theme)</NavLink>
         </div>
       </div>
       <div className={styles['main-body']}>

--- a/style-guide/src/pages/index.js
+++ b/style-guide/src/pages/index.js
@@ -9,6 +9,7 @@ import Breakpoints from './otkit-breakpoints.js';
 import Shadows from './otkit-shadows.js';
 import Grids from './otkit-grids.js';
 import Icons from './otkit-icons.js';
+import IconsTheme from './otkit-icons-theme.js';
 import SectionHeader from '../components/section-header';
 
 export default () => {
@@ -20,7 +21,8 @@ export default () => {
         add an issue, visit the{' '}
         <a href="https://github.com/opentable/design-tokens" target="_blank">
           design-tokens repository
-        </a>.
+        </a>
+        .
       </p>
       <Colors />
       <Typography />
@@ -30,6 +32,7 @@ export default () => {
       <Breakpoints />
       <Shadows />
       <Icons />
+      <IconsTheme />
     </div>
   );
 };

--- a/style-guide/src/pages/otkit-icons-theme.js
+++ b/style-guide/src/pages/otkit-icons-theme.js
@@ -1,0 +1,76 @@
+import React from 'react';
+import _ from 'lodash';
+
+import SectionHeader from '../components/section-header';
+import icons from 'otkit-icons/token.theme.common';
+import colors from 'otkit-colors/token.common';
+import styles from '../styles/otkit-icons.module.css';
+
+class Icons extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      color: '#000000'
+    };
+    this.updateColor = this.updateColor.bind(this);
+  }
+
+  renderSelect() {
+    const keys = Object.keys(colors).sort();
+    return (
+      <div>
+        <select
+          onChange={e => this.updateColor(e.target.value)}
+          value={this.state.color}
+        >
+          <option value="#000000" default>
+            Black - #000000
+          </option>
+          {keys.map(name => (
+            <option key={name} value={colors[name]}>
+              {_.kebabCase(name)} - {colors[name]}
+            </option>
+          ))}
+        </select>
+      </div>
+    );
+  }
+
+  updateColor = color => {
+    this.setState({ color });
+  };
+
+  render() {
+    const { iconSize } = icons;
+    const keys = _.keys(icons).sort();
+    const actualIcons = _.without(keys, 'iconSize');
+
+    const tokens = actualIcons.map(name => {
+      const value = icons[name];
+      return (
+        <div className={styles['card']} key={name}>
+          <div className={styles['icon-block']}>
+            <div
+              className={styles['icon']}
+              dangerouslySetInnerHTML={{ __html: value }}
+              style={{ color: this.state.color }}
+            />
+          </div>
+          <div className={styles['icon-name']}>{_.kebabCase(name)}</div>
+        </div>
+      );
+    });
+    return (
+      <div className={styles['main-container']}>
+        <SectionHeader
+          text="Icons (theme)"
+          type="SectionHeader__small"
+          content={this.renderSelect()}
+        />
+        <div className={styles['section-icon']}>{tokens}</div>
+      </div>
+    );
+  }
+}
+
+export default Icons;


### PR DESCRIPTION
This PR adds a themeable icons styleguide/docs in the Github pages (https://opentable.github.io/design-tokens/otkit-icons/)

![theme](https://user-images.githubusercontent.com/5797965/84463107-197dff80-acb4-11ea-9960-292bfdad49d0.png)
