### PR TITLE
[OTK-143] update otkit-typography-desktop - add xxsmallmedium font

### DIFF
--- a/OTKit/otkit-typography-desktop/token.yml
+++ b/OTKit/otkit-typography-desktop/token.yml
@@ -60,6 +60,20 @@ props:
     type: "size"
     value: "16px"
 
+  # Design decisions for font group xxsmall-medium.
+  # WARNING: This should only be used for footnotes.
+  #
+  # =============================================
+  xxsmall-medium-font-size:
+    type: "size"
+    value: "12px"
+  xxsmall-medium-font-weight:
+    type: "raw"
+    value: "medium"
+  xxsmall-medium-line-height:
+    type: "size"
+    value: "16px"
+
   # Design decisions for font group xsmall-bold.
   #
   # =============================================


### PR DESCRIPTION
we're missing `xxsmall-medium` font size, weight and line height. Need it for this PR https://github.com/opentable/buffet/pull/2652

## JIRA Ticket: 
[OTK-143](https://opentable.atlassian.net/browse/OTK-143)